### PR TITLE
Added missing greek upper case latter Theta.

### DIFF
--- a/KBFRZ71.klc
+++ b/KBFRZ71.klc
@@ -51,7 +51,7 @@ LAYOUT		;an extra '@' at the end is a dead key
 19	P		1	p	P	-1	0025	2030		// p P   % ‰ 
 1a	OEM_6		0	002d	2013	-1	2212	2011		// - –   − ‑ 
 1b	OEM_1		0	002b	00b1	-1	2020	2021		// + ±   † ‡ 
-1e	Q		1	q	Q	-1	03b8	-1		// q Q   θ   
+1e	Q		1	q	Q	-1	03b8	0398		// q Q   θ Θ  
 1f	S		5	s	S	-1	00df	1e9e		// s S   ß ẞ
 20	D		1	d	D	-1	0024	-1		// d D   $   
 21	F		1	f	F	-1	00a4@	-1		// f F   ¤   


### PR DESCRIPTION
Fixes #29.

The latin letter theta is not encoded in the Unicode standard.
Therefore, we use lowercase and uppercase Greek letters Theta instead.

This PR add the missing Greek uppercase letter Theta on <kbd>AltGr</kbd>+<kbd>Q</kbd>.